### PR TITLE
feat: add toString column

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,257 +18,120 @@ To update the below results, run `npm run update-results`
 
 The following tables are generated from the test suite.
 
-### Grouped by URL "PROTOCOL://bafyFoo/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456"
+### Grouped by URL "PROTOCOL://AbC/path/file?a=1&b=2#h"
 
 #### Protocol "ipfs:"
 
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "chrome" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "firefox" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "electron-main" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-chrome" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-firefox" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
+| environment | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `node` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `chrome` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `firefox` | `ipfs://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipfs://abc/path/file?a=1&b=2#h` |
+| `electron-main` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `webworker-chrome` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `webworker-firefox` | `ipfs://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipfs://abc/path/file?a=1&b=2#h` |
 
 #### Protocol "ipns:"
 
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "chrome" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "firefox" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "electron-main" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-chrome" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-firefox" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
+| environment | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `node` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `chrome` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `firefox` | `ipns://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipns://abc/path/file?a=1&b=2#h` |
+| `electron-main` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `webworker-chrome` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `webworker-firefox` | `ipns://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipns://abc/path/file?a=1&b=2#h` |
 
 #### Protocol "http:"
 
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "chrome" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "firefox" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webkit" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "electron-main" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-chrome" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-firefox" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-webkit" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
+| environment | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `node` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `chrome` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `firefox` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `electron-main` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `webworker-chrome` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `webworker-firefox` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
 
 #### Protocol "https:"
 
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "chrome" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "firefox" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webkit" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "electron-main" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-chrome" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-firefox" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-webkit" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
+| environment | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `node` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `chrome` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `firefox` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `electron-main` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `webworker-chrome` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `webworker-firefox` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
 
 #### Protocol "ftp:"
 
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "chrome" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "firefox" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webkit" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "electron-main" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-chrome" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-firefox" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "webworker-webkit" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-
-### Grouped by environment "webworker-webkit"
-
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
+| environment | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `node` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
+| `chrome` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
+| `firefox` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
+| `electron-main` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
+| `webworker-chrome` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
+| `webworker-firefox` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
 
 ### Grouped by environment "webworker-firefox"
 
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ipns:" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
+| protocol | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ipfs:` | `ipfs://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipfs://abc/path/file?a=1&b=2#h` |
+| `ipns:` | `ipns://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipns://abc/path/file?a=1&b=2#h` |
+| `http:` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `https:` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `ftp:` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
 
 ### Grouped by environment "webworker-chrome"
 
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "null" | "" | "" | undefined | "" | "" |
-| "ipns:" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "null" | "" | "" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-
-### Grouped by environment "webkit"
-
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
+| protocol | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ipfs:` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `ipns:` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `http:` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `https:` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `ftp:` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
 
 ### Grouped by environment "node"
 
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
+| protocol | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ipfs:` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `ipns:` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `http:` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `https:` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `ftp:` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
 
 ### Grouped by environment "firefox"
 
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ipns:" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
+| protocol | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ipfs:` | `ipfs://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipfs://abc/path/file?a=1&b=2#h` |
+| `ipns:` | `ipns://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ipns://abc/path/file?a=1&b=2#h` |
+| `http:` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `https:` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `ftp:` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
 
 ### Grouped by environment "electron-main"
 
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
+| protocol | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ipfs:` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `ipns:` | `null` | `AbC` | `AbC` | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `http:` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `https:` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `ftp:` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
 
 ### Grouped by environment "chrome"
 
-| protocol | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "ipfs:" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipfs:" | "null" | "" | "" | undefined | "" | "" |
-| "ipns:" | "null" | "" | "" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ipns:" | "null" | "" | "" | undefined | "" | "" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "http:" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "https:" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "?myQueryK1=123&myQueryK2=456" | "#myHashValue1=123&myHashValue2=456" |
-| "ftp:" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-
-### Grouped by URL "PROTOCOL://bafyFoo"
-
-#### Protocol "ipfs:"
-
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "chrome" | "null" | "" | "" | undefined | "" | "" |
-| "firefox" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "electron-main" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "webworker-chrome" | "null" | "" | "" | undefined | "" | "" |
-| "webworker-firefox" | "ipfs://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-
-#### Protocol "ipns:"
-
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "chrome" | "null" | "" | "" | undefined | "" | "" |
-| "firefox" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "electron-main" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-| "webworker-chrome" | "null" | "" | "" | undefined | "" | "" |
-| "webworker-firefox" | "ipns://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-webkit" | "null" | "bafyFoo" | "bafyFoo" | undefined | "" | "" |
-
-#### Protocol "http:"
-
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "chrome" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "firefox" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webkit" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "electron-main" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-chrome" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-firefox" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-webkit" | "http://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-
-#### Protocol "https:"
-
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "chrome" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "firefox" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webkit" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "electron-main" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-chrome" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-firefox" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-webkit" | "https://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-
-#### Protocol "ftp:"
-
-| environment | origin | host | hostname | path | search | hash |
-| --- | --- | --- | --- | --- | --- | --- |
-| "node" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "chrome" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "firefox" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webkit" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "electron-main" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-chrome" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-firefox" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
-| "webworker-webkit" | "ftp://bafyfoo" | "bafyfoo" | "bafyfoo" | undefined | "" | "" |
+| protocol | origin | host | hostname | path | search | hash | toString |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ipfs:` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipfs://AbC/path/file?a=1&b=2#h` |
+| `ipns:` | `null` | "" | "" | undefined | `?a=1&b=2` | `#h` | `ipns://AbC/path/file?a=1&b=2#h` |
+| `http:` | `http://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `http://abc/path/file?a=1&b=2#h` |
+| `https:` | `https://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `https://abc/path/file?a=1&b=2#h` |
+| `ftp:` | `ftp://abc` | `abc` | `abc` | undefined | `?a=1&b=2` | `#h` | `ftp://abc/path/file?a=1&b=2#h` |
 

--- a/bin/update-readme.js
+++ b/bin/update-readme.js
@@ -109,7 +109,7 @@ async function main () {
   ]
 
   // add tables grouped by urlTemplate
-  const columns = ['environment', 'protocol', 'origin', 'host', 'hostname', 'path', 'search', 'hash']
+  const columns = ['environment', 'protocol', 'origin', 'host', 'hostname', 'path', 'search', 'hash', 'toString']
   // eslint-disable-next-line guard-for-in
   for (const [groupName, groupItems] of Object.entries(groups)) {
     if (groupName.includes('PROTOCOL')) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "aegir build",
-    "clean": "aegir clean",
+    "clean": "aegir clean && rm -f url-results-*.*",
     "lint": "aegir lint",
     "test": "run-s test:*",
     "update-results": "run-s test && node ./bin/update-readme.js",

--- a/src/create-table-results.ts
+++ b/src/create-table-results.ts
@@ -2,11 +2,12 @@ export function valueNormalize (value: any): string | null {
   if (value === undefined) {
     return 'undefined'
   } else if (typeof value === 'object' && value === null) {
-    return null
-  } else if (typeof value === 'string') {
-    return `"${value}"`
+    return 'null'
   }
-  return `${value}`
+  if (value !== "") {
+    return `\u0060${value}\u0060`
+  }
+  return `"${value}"`
 }
 
 export interface TableRow {
@@ -23,6 +24,7 @@ export interface TableRow {
    * mostly for matching against other rows for matching URLS
    */
   urlTemplate: string
+  toString: string
 }
 
 export type TableResults = TableRow[]
@@ -42,6 +44,7 @@ export function createTableResults (urlTemplate: string, environment: string): T
     const newUrlString = urlTemplate.replace(/^PROTOCOL:\/\//, `${protocol}://`)
     const urlObj = new URL(urlTemplate.replace(/^PROTOCOL:\/\//, `${protocol}://`))
     const row: TableRow = {
+      toString: urlObj.toString(),
       environment,
       urlTemplate,
       url: newUrlString,
@@ -65,8 +68,8 @@ export function createMarkdownTableResults (urlTemplate: string, environment: st
   const markdownTableLines = existingTable?.split('\n') ?? [
     '',
     `### Environment: ${environment}`,
-    '| URL              | origin | protocol | host | hostname | path     | search | hash |',
-    '|------------------|--------|----------|------|----------|----------|--------|------|'
+    '| URL              | origin | protocol | host | hostname | path     | search | hash | toString |',
+    '|------------------|--------|----------|------|----------|----------|--------|------|----------|'
   ]
 
   for (const protocol of ALL_PROTOCOLS) {
@@ -80,7 +83,8 @@ export function createMarkdownTableResults (urlTemplate: string, environment: st
       urlObj.hostname,
       urlObj.pathname,
       urlObj.search,
-      urlObj.hash
+      urlObj.hash,
+      urlObj.toString
     ]
 
     markdownTableLines.push(`| ${row.map(valueNormalize).join(' | ')} |`)

--- a/test/urls.spec.js
+++ b/test/urls.spec.js
@@ -26,18 +26,18 @@ describe('URL-test', () => {
   const RUNNER_ENV = process.env.RUNNER_ENV
   if (!RUNNER_ENV) throw new Error('No RUNNER_ENV set')
   describe('ipfs:// URLs', () => {
-    let urlString = getUrlString('ipfs', 'bafyFoo')
-    it(`parses ipfs://bafyFoo in ${RUNNER_ENV}`, () => {
-      const urlString = getUrlString('ipfs', 'bafyFoo')
+    let urlString = getUrlString('ipfs', 'AbC')
+    it(`parses ipfs://AbC in ${RUNNER_ENV}`, () => {
+      const urlString = getUrlString('ipfs', 'AbC')
       const url = new URL(urlString)
 
       if (['node', 'electron-main', 'webkit', 'webworker-webkit'].includes(RUNNER_ENV)) {
         validateObjects(url, {
           origin: null,
           protocol: 'ipfs:',
-          host: 'bafyFoo',
+          host: 'AbC',
           port: '',
-          hostname: 'bafyFoo',
+          hostname: 'AbC',
           hash: '',
           search: '',
           query: undefined,
@@ -54,38 +54,38 @@ describe('URL-test', () => {
           hash: '',
           search: '',
           query: undefined,
-          pathname: '//bafyFoo',
+          pathname: '//AbC',
           href: urlString
         })
       } else if (RUNNER_ENV.includes('firefox')) {
         validateObjects(url, {
-          origin: 'ipfs://bafyfoo',
+          origin: 'ipfs://abc',
           protocol: 'ipfs:',
-          host: 'bafyfoo',
+          host: 'abc',
           port: '',
-          hostname: 'bafyfoo',
+          hostname: 'abc',
           hash: '',
           search: '',
           query: undefined,
           pathname: '/',
-          href: urlString.replace('bafyFoo', 'bafyfoo') + '/'
+          href: urlString.replace('AbC', 'abc') + '/'
         })
       }
     })
 
-    it(`parses ipfs://bafyFoo/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456 in ${RUNNER_ENV}`, () => {
-      urlString = getUrlString('ipfs', 'bafyFoo', '/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456')
+    it(`parses ipfs://AbC/path/file?a=1&b=2#h in ${RUNNER_ENV}`, () => {
+      urlString = getUrlString('ipfs', 'AbC', '/path/file?a=1&b=2#h')
       const url = new URL(urlString)
 
       if (['node', 'electron-main', 'webkit', 'webworker-webkit'].includes(RUNNER_ENV)) {
         validateObjects(url, {
           origin: null,
           protocol: 'ipfs:',
-          host: 'bafyFoo',
+          host: 'AbC',
           port: '',
-          hostname: 'bafyFoo',
-          hash: '#myHashValue1=123&myHashValue2=456',
-          search: '?myQueryK1=123&myQueryK2=456',
+          hostname: 'AbC',
+          hash: '#h',
+          search: '?a=1&b=2',
           query: undefined,
           pathname: '/path/file',
           href: urlString
@@ -97,31 +97,31 @@ describe('URL-test', () => {
           host: '',
           port: '',
           hostname: '',
-          hash: '#myHashValue1=123&myHashValue2=456',
-          search: '?myQueryK1=123&myQueryK2=456',
+          hash: '#h',
+          search: '?a=1&b=2',
           query: undefined,
-          pathname: '//bafyFoo/path/file',
+          pathname: '//AbC/path/file',
           href: urlString
         })
       } else if (RUNNER_ENV.includes('firefox')) {
         validateObjects(url, {
-          origin: 'ipfs://bafyfoo',
+          origin: 'ipfs://abc',
           protocol: 'ipfs:',
-          host: 'bafyfoo',
+          host: 'abc',
           port: '',
-          hostname: 'bafyfoo',
-          hash: '#myHashValue1=123&myHashValue2=456',
-          search: '?myQueryK1=123&myQueryK2=456',
+          hostname: 'abc',
+          hash: '#h',
+          search: '?a=1&b=2',
           query: undefined,
           pathname: '/path/file',
-          href: urlString.replace('bafyFoo', 'bafyfoo')
+          href: urlString.replace('AbC', 'abc')
         })
       }
     })
   })
   describe('ipns:// URLs', () => {
     const protocol = 'ipns'
-    let urlString = getUrlString(protocol, 'bafyFoo')
+    let urlString = getUrlString(protocol, 'AbC')
     it(`parses ${urlString} in ${RUNNER_ENV}`, () => {
       const url = new URL(urlString)
 
@@ -129,9 +129,9 @@ describe('URL-test', () => {
         validateObjects(url, {
           origin: null,
           protocol: 'ipns:',
-          host: 'bafyFoo',
+          host: 'AbC',
           port: '',
-          hostname: 'bafyFoo',
+          hostname: 'AbC',
           hash: '',
           search: '',
           query: undefined,
@@ -148,38 +148,38 @@ describe('URL-test', () => {
           hash: '',
           search: '',
           query: undefined,
-          pathname: '//bafyFoo',
+          pathname: '//AbC',
           href: urlString
         })
       } else if (RUNNER_ENV.includes('firefox')) {
         validateObjects(url, {
-          origin: 'ipns://bafyfoo',
+          origin: 'ipns://abc',
           protocol: 'ipns:',
-          host: 'bafyfoo',
+          host: 'abc',
           port: '',
-          hostname: 'bafyfoo',
+          hostname: 'abc',
           hash: '',
           search: '',
           query: undefined,
           pathname: '/',
-          href: urlString.replace('bafyFoo', 'bafyfoo') + '/'
+          href: urlString.replace('AbC', 'abc') + '/'
         })
       }
     })
 
-    it(`parses ipns://bafyFoo/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456 in ${RUNNER_ENV}`, () => {
-      urlString = getUrlString('ipns', 'bafyFoo', '/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456')
+    it(`parses ipns://AbC/path/file?a=1&b=2#h in ${RUNNER_ENV}`, () => {
+      urlString = getUrlString('ipns', 'AbC', '/path/file?a=1&b=2#h')
       const url = new URL(urlString)
 
       if (['node', 'electron-main', 'webkit', 'webworker-webkit'].includes(RUNNER_ENV)) {
         validateObjects(url, {
           origin: null,
           protocol: 'ipns:',
-          host: 'bafyFoo',
+          host: 'AbC',
           port: '',
-          hostname: 'bafyFoo',
-          hash: '#myHashValue1=123&myHashValue2=456',
-          search: '?myQueryK1=123&myQueryK2=456',
+          hostname: 'AbC',
+          hash: '#h',
+          search: '?a=1&b=2',
           query: undefined,
           pathname: '/path/file',
           href: urlString
@@ -191,24 +191,24 @@ describe('URL-test', () => {
           host: '',
           port: '',
           hostname: '',
-          hash: '#myHashValue1=123&myHashValue2=456',
-          search: '?myQueryK1=123&myQueryK2=456',
+          hash: '#h',
+          search: '?a=1&b=2',
           query: undefined,
-          pathname: '//bafyFoo/path/file',
+          pathname: '//AbC/path/file',
           href: urlString
         })
       } else if (RUNNER_ENV.includes('firefox')) {
         validateObjects(url, {
-          origin: 'ipns://bafyfoo',
+          origin: 'ipns://abc',
           protocol: 'ipns:',
-          host: 'bafyfoo',
+          host: 'abc',
           port: '',
-          hostname: 'bafyfoo',
-          hash: '#myHashValue1=123&myHashValue2=456',
-          search: '?myQueryK1=123&myQueryK2=456',
+          hostname: 'abc',
+          hash: '#h',
+          search: '?a=1&b=2',
           query: undefined,
           pathname: '/path/file',
-          href: urlString.replace('bafyFoo', 'bafyfoo')
+          href: urlString.replace('AbC', 'abc')
         })
       }
     })
@@ -216,119 +216,118 @@ describe('URL-test', () => {
 
   describe('http:// URLs', () => {
     const protocol = 'http'
-    let urlString = getUrlString(protocol, 'bafyFoo')
+    let urlString = getUrlString(protocol, 'AbC')
     it(`parses ${urlString} URLs work in ${RUNNER_ENV}`, () => {
       const url = new URL(urlString)
       validateObjects(url, {
-        origin: 'http://bafyfoo',
+        origin: 'http://abc',
         protocol: 'http:',
-        host: 'bafyfoo',
+        host: 'abc',
         port: '',
-        hostname: 'bafyfoo',
+        hostname: 'abc',
         hash: '',
         search: '',
         query: undefined,
         pathname: '/',
-        href: urlString.replace('bafyFoo', 'bafyfoo') + '/'
+        href: urlString.replace('AbC', 'abc') + '/'
       })
     })
 
-    it(`parses http://bafyFoo/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456 in ${RUNNER_ENV}`, () => {
-      urlString = getUrlString('http', 'bafyFoo', '/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456')
+    it(`parses http://AbC/path/file?a=1&b=2#h in ${RUNNER_ENV}`, () => {
+      urlString = getUrlString('http', 'AbC', '/path/file?a=1&b=2#h')
       const url = new URL(urlString)
       validateObjects(url, {
-        origin: 'http://bafyfoo',
+        origin: 'http://abc',
         protocol: 'http:',
-        host: 'bafyfoo',
+        host: 'abc',
         port: '',
-        hostname: 'bafyfoo',
-        hash: '#myHashValue1=123&myHashValue2=456',
-        search: '?myQueryK1=123&myQueryK2=456',
+        hostname: 'abc',
+        hash: '#h',
+        search: '?a=1&b=2',
         query: undefined,
         pathname: '/path/file',
-        href: urlString.replace('bafyFoo', 'bafyfoo')
+        href: urlString.replace('AbC', 'abc')
       })
     })
   })
 
   describe('https:// URLs', () => {
     const protocol = 'https'
-    let urlString = getUrlString(protocol, 'bafyFoo')
+    let urlString = getUrlString(protocol, 'AbC')
     it(`parses ${urlString} in ${RUNNER_ENV}`, () => {
       const url = new URL(urlString)
       validateObjects(url, {
-        origin: 'https://bafyfoo',
+        origin: 'https://abc',
         protocol: 'https:',
-        host: 'bafyfoo',
+        host: 'abc',
         port: '',
-        hostname: 'bafyfoo',
+        hostname: 'abc',
         hash: '',
         search: '',
         query: undefined,
         pathname: '/',
-        href: urlString.replace('bafyFoo', 'bafyfoo') + '/'
+        href: urlString.replace('AbC', 'abc') + '/'
       })
     })
 
-    it(`parses https://bafyFoo/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456 in ${RUNNER_ENV}`, () => {
-      urlString = getUrlString('https', 'bafyFoo', '/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456')
+    it(`parses https://AbC/path/file?a=1&b=2#h in ${RUNNER_ENV}`, () => {
+      urlString = getUrlString('https', 'AbC', '/path/file?a=1&b=2#h')
       const url = new URL(urlString)
       validateObjects(url, {
-        origin: 'https://bafyfoo',
+        origin: 'https://abc',
         protocol: 'https:',
-        host: 'bafyfoo',
+        host: 'abc',
         port: '',
-        hostname: 'bafyfoo',
-        hash: '#myHashValue1=123&myHashValue2=456',
-        search: '?myQueryK1=123&myQueryK2=456',
+        hostname: 'abc',
+        hash: '#h',
+        search: '?a=1&b=2',
         query: undefined,
         pathname: '/path/file',
-        href: urlString.replace('bafyFoo', 'bafyfoo')
+        href: urlString.replace('AbC', 'abc')
       })
     })
   })
 
   describe('ftp:// URLs', () => {
     const protocol = 'ftp'
-    let urlString = getUrlString(protocol, 'bafyFoo')
+    let urlString = getUrlString(protocol, 'AbC')
     it(`parses ${urlString} in ${RUNNER_ENV}`, () => {
       const url = new URL(urlString)
       validateObjects(url, {
-        origin: 'ftp://bafyfoo',
+        origin: 'ftp://abc',
         protocol: 'ftp:',
-        host: 'bafyfoo',
+        host: 'abc',
         port: '',
-        hostname: 'bafyfoo',
+        hostname: 'abc',
         hash: '',
         search: '',
         query: undefined,
         pathname: '/',
-        href: urlString.replace('bafyFoo', 'bafyfoo') + '/'
+        href: urlString.replace('AbC', 'abc') + '/'
       })
     })
 
-    it(`parses ftp://bafyFoo/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456 in ${RUNNER_ENV}`, () => {
-      urlString = getUrlString('ftp', 'bafyFoo', '/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456')
+    it(`parses ftp://AbC/path/file?a=1&b=2#h in ${RUNNER_ENV}`, () => {
+      urlString = getUrlString('ftp', 'AbC', '/path/file?a=1&b=2#h')
       const url = new URL(urlString)
       validateObjects(url, {
-        origin: 'ftp://bafyfoo',
+        origin: 'ftp://abc',
         protocol: 'ftp:',
-        host: 'bafyfoo',
+        host: 'abc',
         port: '',
-        hostname: 'bafyfoo',
-        hash: '#myHashValue1=123&myHashValue2=456',
-        search: '?myQueryK1=123&myQueryK2=456',
+        hostname: 'abc',
+        hash: '#h',
+        search: '?a=1&b=2',
         query: undefined,
         pathname: '/path/file',
-        href: urlString.replace('bafyFoo', 'bafyfoo')
+        href: urlString.replace('AbC', 'abc')
       })
     })
   })
   it('writes results to markdown files', async () => {
     expect(true).to.be.true()
     const URLS = [
-      'PROTOCOL://bafyFoo',
-      'PROTOCOL://bafyFoo/path/file?myQueryK1=123&myQueryK2=456#myHashValue1=123&myHashValue2=456'
+      'PROTOCOL://AbC/path/file?a=1&b=2#h'
     ]
     for (const url of URLS) {
       const table = createTableResults(url, RUNNER_ENV)


### PR DESCRIPTION
This PR shortens test values and adds `toString` column, which shows how stringified `URL` looks like.

This allows us to show vendors how non-HTTP URLs are mutated.

Exmample: https://github.com/SgtPooki/new-URL-protocol-hostname-path-diff/blob/ea06d9a7413f049a6c7f06b21cc5e064809ff3f7/README.md